### PR TITLE
Bug:Search for nodes only when wan_only=False

### DIFF
--- a/dask_elk/client.py
+++ b/dask_elk/client.py
@@ -25,9 +25,16 @@ class DaskElasticClient(object):
 
     """
 
-    def __init__(self, host='localhost', port=9200, client_klass=Elasticsearch,
-                 username=None, password=None, wan_only=False,
-                 **client_kwargs):
+    def __init__(
+        self,
+        host="localhost",
+        port=9200,
+        client_klass=Elasticsearch,
+        username=None,
+        password=None,
+        wan_only=False,
+        **client_kwargs
+    ):
         """
         Constructor for DaskElasticClient object
 
@@ -74,10 +81,16 @@ class DaskElasticClient(object):
     def wan_only(self):
         return self.__wan_only
 
-    def read(self, query=None, index=None, doc_type=None,
-             number_of_docs_per_partition=1000000, size=1000,
-             fields_as_list=None,
-             **kwargs):
+    def read(
+        self,
+        query=None,
+        index=None,
+        doc_type=None,
+        number_of_docs_per_partition=1000000,
+        size=1000,
+        fields_as_list=None,
+        **kwargs
+    ):
 
         """
         Method to read from elasticsearch index/ices
@@ -107,36 +120,39 @@ class DaskElasticClient(object):
 
         # Get nodes info first
         node_registry = NodeRegistry()
-        node_registry.get_nodes_from_elastic(elk_client)
+        if not self.wan_only:
+            node_registry.get_nodes_from_elastic(elk_client)
 
         index_registry = IndexRegistry(nodes_registry=node_registry)
-        index_registry.get_indices_from_elasticsearch(elk_client,
-                                                      index=index,
-                                                      doc_type=doc_type)
+        index_registry.get_indices_from_elasticsearch(
+            elk_client, index=index, doc_type=doc_type
+        )
 
         meta = index_registry.calculate_meta()
         if fields_as_list:
-            for field in map(str.strip, fields_as_list.split(',')):
+            for field in map(str.strip, fields_as_list.split(",")):
                 if field in meta.columns:
                     meta[field] = meta[field].astype(object)
 
         delayed_objs = []
         for index in index_registry.indices.values():
             for shard in index.shards:
-                no_of_docs = IndexRegistry.get_documents_count(elk_client,
-                                                               query, index,
-                                                               shard=shard)
+                no_of_docs = IndexRegistry.get_documents_count(
+                    elk_client, query, index, shard=shard
+                )
                 node = None
                 if self.wan_only:
-                    node = Node(node_id='master', publish_address=self.hosts)
+                    node = Node(node_id="master", publish_address=self.hosts)
 
                 number_of_partitions = self.__get_number_of_partitions(
-                    no_of_docs, number_of_docs_per_partition)
+                    no_of_docs, number_of_docs_per_partition
+                )
                 for slice_id in range(number_of_partitions):
                     part_reader = self.__create_partition_reader(
                         index,
                         shard,
-                        node, query,
+                        node,
+                        query,
                         doc_type,
                         meta,
                         number_of_partitions,
@@ -149,7 +165,7 @@ class DaskElasticClient(object):
 
         return dd.from_delayed(delayed_objs, meta=meta)
 
-    def save(self, data, index, doc_type, action='index'):
+    def save(self, data, index, doc_type, action="index"):
         """
         Save a dask dataframe to Elasticsearch
 
@@ -164,17 +180,30 @@ class DaskElasticClient(object):
         client_cls = self.__client_klass
         client_args = self.__client_args
 
-        bulk_arguments = {'index': index, 'doc_type': doc_type,
-                          'action': action,
-                          }
-        data = data.map_partitions(bulk_save, client_cls, client_args,
-                                   meta=data, **bulk_arguments)
+        bulk_arguments = {
+            "index": index,
+            "doc_type": doc_type,
+            "action": action,
+        }
+        data = data.map_partitions(
+            bulk_save, client_cls, client_args, meta=data, **bulk_arguments
+        )
 
         return data
 
-    def __create_partition_reader(self, index, shard, node, query, doc_type,
-                                  meta, number_of_partitions, slice_id, size,
-                                  **scan_arguments):
+    def __create_partition_reader(
+        self,
+        index,
+        shard,
+        node,
+        query,
+        doc_type,
+        meta,
+        number_of_partitions,
+        slice_id,
+        size,
+        **scan_arguments
+    ):
         """
         Create partition reader object
         :param dask_elk.elk_entities.index.Index index: Index to fetch data
@@ -191,7 +220,8 @@ class DaskElasticClient(object):
         """
 
         part_reader = PartitionReader(
-            index=index, shard=shard,
+            index=index,
+            shard=shard,
             meta=meta,
             node=node,
             doc_type=doc_type,
@@ -205,7 +235,8 @@ class DaskElasticClient(object):
 
         if number_of_partitions > 1:
             part_reader = PartitionReader(
-                index=index, shard=shard,
+                index=index,
+                shard=shard,
                 meta=meta,
                 node=node,
                 doc_type=doc_type,
@@ -224,11 +255,9 @@ class DaskElasticClient(object):
         return partitions
 
     def __create_client_args(self, client_kwargs):
-        client_arguments = {'hosts': make_sequence(self.hosts),
-                            'port': self.port}
+        client_arguments = {"hosts": make_sequence(self.hosts), "port": self.port}
         if self.username and self.password:
-            client_arguments.update(
-                {'http_auth': (self.username, self.password)})
+            client_arguments.update({"http_auth": (self.username, self.password)})
         if client_kwargs:
             client_arguments.update(client_kwargs)
         return client_arguments

--- a/dask_elk/elk_entities/node.py
+++ b/dask_elk/elk_entities/node.py
@@ -1,7 +1,7 @@
 class Node(object):
-
-    def __init__(self, node_id, publish_address,
-                 node_type=('master', 'data', 'ingest')):
+    def __init__(
+        self, node_id, publish_address, node_type=("master", "data", "ingest")
+    ):
         """
         Representation of an elasticsearch node in the cluster
         :param str node_id: The id of the node
@@ -41,12 +41,20 @@ class NodeRegistry(object):
         """
         node_client = elk_client.nodes
         resp = node_client.info()
-        for node_id, node_info in resp['nodes'].items():
-            publish_address = node_info['http']['publish_address']
-            roles = node_info['roles']
-            self.__nodes[node_id] = Node(node_id=node_id,
-                                         publish_address=publish_address,
-                                         node_type=tuple(roles))
+        try:
+            for node_id, node_info in resp["nodes"].items():
+                publish_address = node_info["http"]["publish_address"]
+                roles = node_info["roles"]
+                self.__nodes[node_id] = Node(
+                    node_id=node_id,
+                    publish_address=publish_address,
+                    node_type=tuple(roles),
+                )
+        except KeyError:
+            raise Exception(
+                "Could not get publish address. Try wan_only "
+                "option when creating a client"
+            )
 
     def get_node_by_id(self, node_id):
         """

--- a/tests/elk_entities/test_nodes.py
+++ b/tests/elk_entities/test_nodes.py
@@ -14,19 +14,29 @@ class TestNodeRegistry(unittest.TestCase):
         node_registry = NodeRegistry()
         node_registry.get_nodes_from_elastic(self.elk_client)
         self.assertEqual(1, len(node_registry.nodes))
-        self.assertIn('E43TT5r9Q9-VWckuAXLf0Q', node_registry.nodes)
-        node = node_registry.nodes['E43TT5r9Q9-VWckuAXLf0Q']
-        self.assertEqual('E43TT5r9Q9-VWckuAXLf0Q', node.node_id)
-        self.assertEqual('1.1.1.1:9200', node.publish_address)
-        self.assertEqual(('master', 'data', 'ingest'), node.node_type)
+        self.assertIn("E43TT5r9Q9-VWckuAXLf0Q", node_registry.nodes)
+        node = node_registry.nodes["E43TT5r9Q9-VWckuAXLf0Q"]
+        self.assertEqual("E43TT5r9Q9-VWckuAXLf0Q", node.node_id)
+        self.assertEqual("1.1.1.1:9200", node.publish_address)
+        self.assertEqual(("master", "data", "ingest"), node.node_type)
+
+    def test_get_nodes_from_elastic_raises_key_error(self):
+        node_registry = NodeRegistry()
+        self.elk_client.nodes.info.return_value = (
+            self.get_mocked_node_resp_no_pub_address()
+        )
+        with self.assertRaises(Exception) as exc_context:
+            node_registry.get_nodes_from_elastic(self.elk_client)
+        exception = exc_context.exception
+        self.assertEqual(
+            "Could not get publish address. Try wan_only "
+            "option when creating a client",
+            str(exception),
+        )
 
     def __get_mocked_node_resp(self):
         return {
-            "_nodes": {
-                "total": 1,
-                "successful": 1,
-                "failed": 0
-            },
+            "_nodes": {"total": 1, "successful": 1, "failed": 0},
             "cluster_name": "docker-cluster",
             "nodes": {
                 "E43TT5r9Q9-VWckuAXLf0Q": {
@@ -37,159 +47,273 @@ class TestNodeRegistry(unittest.TestCase):
                     "version": "6.2.2",
                     "build_hash": "10b1edd",
                     "total_indexing_buffer": 103887667,
-                    "roles": [
-                        "master",
-                        "data",
-                        "ingest"
-                    ],
+                    "roles": ["master", "data", "ingest"],
                     "settings": {
-                        "cluster": {
-                            "name": "docker-cluster"
-                        },
-                        "node": {
-                            "name": "E43TT5r"
-                        },
+                        "cluster": {"name": "docker-cluster"},
+                        "node": {"name": "E43TT5r"},
                         "path": {
                             "logs": "/usr/share/elasticsearch/logs",
-                            "home": "/usr/share/elasticsearch"
+                            "home": "/usr/share/elasticsearch",
                         },
                         "discovery": {
                             "type": "single-node",
-                            "zen": {
-                                "minimum_master_nodes": "1"
-                            }
+                            "zen": {"minimum_master_nodes": "1"},
                         },
-                        "client": {
-                            "type": "node"
-                        },
-                        "http": {
-                            "type": {
-                                "default": "netty4"
-                            }
-                        },
-                        "transport": {
-                            "type": {
-                                "default": "netty4"
-                            }
-                        },
-                        "network": {
-                            "host": "0.0.0.0"
-                        }
+                        "client": {"type": "node"},
+                        "http": {"type": {"default": "netty4"}},
+                        "transport": {"type": {"default": "netty4"}},
+                        "network": {"host": "0.0.0.0"},
                     },
                     "process": {
                         "refresh_interval_in_millis": 1000,
                         "id": 1,
-                        "mlockall": "false"
+                        "mlockall": "false",
                     },
-
                     "thread_pool": {
                         "force_merge": {
                             "type": "fixed",
                             "min": 1,
                             "max": 1,
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "fetch_shard_started": {
                             "type": "scaling",
                             "min": 1,
                             "max": 8,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "listener": {
                             "type": "fixed",
                             "min": 2,
                             "max": 2,
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "index": {
                             "type": "fixed",
                             "min": 4,
                             "max": 4,
-                            "queue_size": 200
+                            "queue_size": 200,
                         },
                         "refresh": {
                             "type": "scaling",
                             "min": 1,
                             "max": 2,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "generic": {
                             "type": "scaling",
                             "min": 4,
                             "max": 128,
                             "keep_alive": "30s",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "warmer": {
                             "type": "scaling",
                             "min": 1,
                             "max": 2,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "search": {
                             "type": "fixed_auto_queue_size",
                             "min": 7,
                             "max": 7,
-                            "queue_size": 1000
+                            "queue_size": 1000,
                         },
                         "flush": {
                             "type": "scaling",
                             "min": 1,
                             "max": 2,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "fetch_shard_store": {
                             "type": "scaling",
                             "min": 1,
                             "max": 8,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "management": {
                             "type": "scaling",
                             "min": 1,
                             "max": 5,
                             "keep_alive": "5m",
-                            "queue_size": -1
+                            "queue_size": -1,
                         },
                         "get": {
                             "type": "fixed",
                             "min": 4,
                             "max": 4,
-                            "queue_size": 1000
+                            "queue_size": 1000,
                         },
                         "bulk": {
                             "type": "fixed",
                             "min": 4,
                             "max": 4,
-                            "queue_size": 200
+                            "queue_size": 200,
                         },
                         "snapshot": {
                             "type": "scaling",
                             "min": 1,
                             "max": 2,
                             "keep_alive": "5m",
-                            "queue_size": -1
-                        }
+                            "queue_size": -1,
+                        },
                     },
                     "transport": {
-                        "bound_address": [
-                            "0.0.0.0:9300"
-                        ],
+                        "bound_address": ["0.0.0.0:9300"],
                         "publish_address": "1.1.1.1:9300",
-                        "profiles": {}
+                        "profiles": {},
                     },
                     "http": {
-                        "bound_address": [
-                            "0.0.0.0:9200"
-                        ],
+                        "bound_address": ["0.0.0.0:9200"],
                         "publish_address": "1.1.1.1:9200",
-                        "max_content_length_in_bytes": 104857600
-                    }
+                        "max_content_length_in_bytes": 104857600,
+                    },
                 }
-            }
+            },
+        }
+
+    def get_mocked_node_resp_no_pub_address(self):
+        return {
+            "_nodes": {"total": 1, "successful": 1, "failed": 0},
+            "cluster_name": "docker-cluster",
+            "nodes": {
+                "E43TT5r9Q9-VWckuAXLf0Q": {
+                    "name": "E43TT5r",
+                    "transport_address": "1.1.1.1:9300",
+                    "host": "1.1.1.1",
+                    "ip": "1.1.1.1",
+                    "version": "6.2.2",
+                    "build_hash": "10b1edd",
+                    "total_indexing_buffer": 103887667,
+                    "roles": ["master", "data", "ingest"],
+                    "settings": {
+                        "cluster": {"name": "docker-cluster"},
+                        "node": {"name": "E43TT5r"},
+                        "path": {
+                            "logs": "/usr/share/elasticsearch/logs",
+                            "home": "/usr/share/elasticsearch",
+                        },
+                        "discovery": {
+                            "type": "single-node",
+                            "zen": {"minimum_master_nodes": "1"},
+                        },
+                        "client": {"type": "node"},
+                        "http": {"type": {"default": "netty4"}},
+                        "transport": {"type": {"default": "netty4"}},
+                        "network": {"host": "0.0.0.0"},
+                    },
+                    "process": {
+                        "refresh_interval_in_millis": 1000,
+                        "id": 1,
+                        "mlockall": "false",
+                    },
+                    "thread_pool": {
+                        "force_merge": {
+                            "type": "fixed",
+                            "min": 1,
+                            "max": 1,
+                            "queue_size": -1,
+                        },
+                        "fetch_shard_started": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 8,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "listener": {
+                            "type": "fixed",
+                            "min": 2,
+                            "max": 2,
+                            "queue_size": -1,
+                        },
+                        "index": {
+                            "type": "fixed",
+                            "min": 4,
+                            "max": 4,
+                            "queue_size": 200,
+                        },
+                        "refresh": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 2,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "generic": {
+                            "type": "scaling",
+                            "min": 4,
+                            "max": 128,
+                            "keep_alive": "30s",
+                            "queue_size": -1,
+                        },
+                        "warmer": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 2,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "search": {
+                            "type": "fixed_auto_queue_size",
+                            "min": 7,
+                            "max": 7,
+                            "queue_size": 1000,
+                        },
+                        "flush": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 2,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "fetch_shard_store": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 8,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "management": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 5,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                        "get": {
+                            "type": "fixed",
+                            "min": 4,
+                            "max": 4,
+                            "queue_size": 1000,
+                        },
+                        "bulk": {
+                            "type": "fixed",
+                            "min": 4,
+                            "max": 4,
+                            "queue_size": 200,
+                        },
+                        "snapshot": {
+                            "type": "scaling",
+                            "min": 1,
+                            "max": 2,
+                            "keep_alive": "5m",
+                            "queue_size": -1,
+                        },
+                    },
+                    "transport": {
+                        "bound_address": ["0.0.0.0:9300"],
+                        "profiles": {},
+                    },
+                    "http": {
+                        "bound_address": ["0.0.0.0:9200"],
+                        "max_content_length_in_bytes": 104857600,
+                    },
+                }
+            },
         }


### PR DESCRIPTION
bug: No publish_address field when nodes ip is not accessiblefrom outside the cluster

- Catch exception when key error and inform user
- Check for nodes only when wan_only is False

closes: #26 